### PR TITLE
feat: add support for removing unused TypeScript enum declarations

### DIFF
--- a/fixtures/enum/input.ts
+++ b/fixtures/enum/input.ts
@@ -1,0 +1,22 @@
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+
+enum Size {
+  Small,
+  Medium,
+  Large,
+}
+
+enum Status {
+  Active,
+  Inactive,
+}
+
+const mySize = Size.Medium;
+const myStatus = Status.Active;
+
+console.log(mySize, myStatus);
+

--- a/fixtures/enum/output.ts
+++ b/fixtures/enum/output.ts
@@ -1,0 +1,16 @@
+enum Size {
+  Small,
+  Medium,
+  Large,
+}
+
+enum Status {
+  Active,
+  Inactive,
+}
+
+const mySize = Size.Medium;
+const myStatus = Status.Active;
+
+console.log(mySize, myStatus);
+

--- a/fixtures/eslint.config.js
+++ b/fixtures/eslint.config.js
@@ -2,7 +2,14 @@ import tseslint from 'typescript-eslint';
 import { defineConfig } from 'eslint/config';
 
 export default defineConfig({
+  files: ['**/*.js', '**/*.ts'],
   plugins: {
     '@typescript-eslint': tseslint.plugin,
+  },
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      project: false,
+    },
   },
 });

--- a/index.js
+++ b/index.js
@@ -105,7 +105,8 @@ function findParentDeclaration(node) {
     !ts.isVariableStatement(node) &&
     !ts.isClassDeclaration(node) &&
     !ts.isInterfaceDeclaration(node) &&
-    !ts.isTypeAliasDeclaration(node)
+    !ts.isTypeAliasDeclaration(node) &&
+    !ts.isEnumDeclaration(node)
   ) {
     node = node.parent;
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typescript": "^5.0.0"
   },
   "scripts": {
-    "test": "node --test ./test",
+    "test": "node --test ./test/*.test.js",
     "test:eslint": "eslint -c fixtures/eslint.config.js --rule 'no-unused-vars: error' --quiet -f json fixtures/file.js | ./index.js",
     "test:ts-eslint": "eslint -c fixtures/eslint.config.js --rule 'no-unused-vars: off' --rule '@typescript-eslint/no-unused-vars: error' --quiet -f json fixtures | ./index.js",
     "test:biome": "biome lint --only correctness/noUnusedVariables --reporter json fixtures | ./index.js",

--- a/test/eslint.test.js
+++ b/test/eslint.test.js
@@ -63,3 +63,8 @@ test('basic combine', () => {
   execLint(path.join(fixturesDir, `${dir}/input.js`), path.join(fixturesDir, `${dir}/output.js`), runEsLint);
   execLint(path.join(fixturesDir, `${dir}/input.js`), path.join(fixturesDir, `${dir}/output.js`), runTsEslint);
 });
+
+test('basic enum', () => {
+  const dir = '/enum';
+  execLint(path.join(fixturesDir, `${dir}/input.ts`), path.join(fixturesDir, `${dir}/output.ts`), runTsEslint);
+});


### PR DESCRIPTION
This change adds support for detecting and removing unused TypeScript enum declarations when they are flagged as unused by linters.

Changes:
- Added ts.isEnumDeclaration check in findParentDeclaration function
- Created test fixtures for enum removal (input.ts and output.ts)
- Added test case to verify enum removal functionality
- Updated ESLint config to properly parse TypeScript files
- Fixed npm test script to correctly run test files (couldn't get `npm test` to work unless I instructed it to look at `.test.js` files)