### PR TITLE
fix: fix no-unused-vars catch clause error no suggestions

### DIFF
--- a/fixtures/try-catch/input.js
+++ b/fixtures/try-catch/input.js
@@ -1,0 +1,12 @@
+try {
+  throw new Error('test');
+} catch (e) {
+  console.log('catch');
+  function hello() {}
+} finally {
+  console.log('finally');
+}
+
+try {
+  throw new Error('test');
+} catch (/** test */e ) {}

--- a/fixtures/try-catch/output.js
+++ b/fixtures/try-catch/output.js
@@ -1,0 +1,11 @@
+try {
+  throw new Error('test');
+} catch {
+  console.log('catch');
+} finally {
+  console.log('finally');
+}
+
+try {
+  throw new Error('test');
+} catch {}

--- a/test/eslint.test.js
+++ b/test/eslint.test.js
@@ -68,3 +68,9 @@ test('basic enum', () => {
   const dir = '/enum';
   execLint(path.join(fixturesDir, `${dir}/input.ts`), path.join(fixturesDir, `${dir}/output.ts`), runTsEslint);
 });
+
+test('basic try-catch', () => {
+  const dir = '/try-catch';
+  execLint(path.join(fixturesDir, `${dir}/input.js`), path.join(fixturesDir, `${dir}/output.js`), runEsLint);
+  execLint(path.join(fixturesDir, `${dir}/input.js`), path.join(fixturesDir, `${dir}/output.js`), runTsEslint);
+});


### PR DESCRIPTION
At eslint, the unused variables in catch clause don't have suggestions.

The previous logic `try {} catch(e) {}` would be converted to `try {} catch() {}` which has syntax errors. The new logic will convert it to `try {} catch {}`.