### PR TITLE
feat: remove entire destructuring statement when all elements are unused

### DIFF
--- a/fixtures/destructure/input.js
+++ b/fixtures/destructure/input.js
@@ -1,0 +1,9 @@
+const utils = { foo: 1, bar: 2, baz: 3 };
+const { foo, bar, baz } = utils;
+
+console.log('All object destructured elements are unused');
+
+const arr = [1, 2, 3];
+const [x, y, z] = arr;
+
+console.log('All array destructured elements are unused');

--- a/fixtures/destructure/output.js
+++ b/fixtures/destructure/output.js
@@ -1,0 +1,7 @@
+const utils = { foo: 1, bar: 2, baz: 3 };
+
+console.log('All object destructured elements are unused');
+
+const arr = [1, 2, 3];
+
+console.log('All array destructured elements are unused');

--- a/test/eslint.test.js
+++ b/test/eslint.test.js
@@ -74,3 +74,9 @@ test('basic try-catch', () => {
   execLint(path.join(fixturesDir, `${dir}/input.js`), path.join(fixturesDir, `${dir}/output.js`), runEsLint);
   execLint(path.join(fixturesDir, `${dir}/input.js`), path.join(fixturesDir, `${dir}/output.js`), runTsEslint);
 });
+
+test('basic destructure', () => {
+  const dir = '/destructure';
+  execLint(path.join(fixturesDir, `${dir}/input.js`), path.join(fixturesDir, `${dir}/output.js`), runEsLint);
+  execLint(path.join(fixturesDir, `${dir}/input.js`), path.join(fixturesDir, `${dir}/output.js`), runTsEslint);
+});


### PR DESCRIPTION
Previously, when all elements in a de-structuring pattern were unused, we would leave behind an empty de-structuring statement like `const { } = utils;`. Now it properly removes the whole thing. And added a test case to verify that behavior.