### PR TITLE
fix: use line and column instead of offset

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function transformOxlint(input) {
       if (!output[filePath]) {
         output[filePath] = { filePath, positions: [] };
       }
-      output[filePath].positions.push(result.labels[0].span.offset);
+      output[filePath].positions.push([result.labels[0].span.line - 1, result.labels[0].span.column - 1]);
       return output;
     }, {});
   return Object.values(groupedByFile);


### PR DESCRIPTION
By using the line+column instead of offset it fixed one specific use case described in the issue, is it ok for you to keep using line+column just like the eslint transform function ? 